### PR TITLE
Small Updates to Necromancer

### DIFF
--- a/necromancer.sh
+++ b/necromancer.sh
@@ -44,8 +44,13 @@ if [ "$newPackageName" != "$oldPackageName" ]; then
 
     mv src/main/java/io/intrepid/skeleton/SkeletonApplication.java src/main/java/io/intrepid/skeleton/${newApplicationCapitalizedName}Application.java
 
+    # Not all Macs have LANG set. If they dont and its not C SED can error with 'sed: RE error: illegal byte sequence'.
+    #    Because -exec subshells... we need to export our environment... So store the one we came in with... Export 'C' then reset.
+    OLD_LANG=$LANG
+    export LANG=C
     find . -type f \( ! -iname "*.png" \) -exec sed -i '' "s/$oldPackageName/$newPackageName/g" {} \;
     find . -type f \( ! -iname "*.png" \) -exec sed -i '' "s/$oldApplicationCapitalizedName/$newApplicationCapitalizedName/g" {} \;
+    export LANG=$OLD_LANG
 
     mkdir temp
     declare -a srcDirs=("androidTest" "main" "test")

--- a/necromancer.sh
+++ b/necromancer.sh
@@ -8,7 +8,8 @@ oldApplicationCapitalizedName="Skeleton"
 oldDirectoryName="io/intrepid/skeleton"
 oldDirectoryPrefix="io/intrepid/"
 
-packageRegex="([a-z]+\.){1,3}([a-z]+)$"
+# We do not check for Java keywords... We should... but we don't. http://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
+packageRegex='^([a-z_][a-z_0-9]*\.)*([A-z_][A-z_0-9]+)$'
 
 downloadDirectory=./
 newPackageName=$oldPackageName

--- a/necromancer.sh
+++ b/necromancer.sh
@@ -8,8 +8,8 @@ oldApplicationCapitalizedName="Skeleton"
 oldDirectoryName="io/intrepid/skeleton"
 oldDirectoryPrefix="io/intrepid/"
 
-# We do not check for Java keywords... We should... but we don't. http://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
-packageRegex='^([a-z_][a-z_0-9]*\.)*([A-z_][A-z_0-9]+)$'
+# We do not check for Java keywords... We should... but we don't, we also enforce lowercase names. http://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
+packageRegex='^([a-z_][a-z_0-9]*\.)*([a-z_][a-z_0-9]+)$'
 
 downloadDirectory=./
 newPackageName=$oldPackageName

--- a/necromancer.sh
+++ b/necromancer.sh
@@ -30,7 +30,7 @@ if [[ $newPackageName =~ $packageRegex ]]; then
     newApplicationCapitalizedName="$(tr '[:lower:]' '[:upper:]' <<< ${newApplicationName:0:1})${newApplicationName:1}"
     newDirectoryName=${newPackageName//\./\/}
 else
-    echo "The package name should be in the for of x.y.z";
+    echo "The package name should be in the form of x.y.z. Package parts cannot start with an integer or end with a full stop ('.').";
     exit
 fi
 


### PR DESCRIPTION
# Changes
- Update to Package Name checker to better match the formal Java ruleset, which is what Google points us to.
- Fix for minor typo in the error message displayed as well as codifying reminders of some of the rules.
- Updating the LANG variable before calling sed to resolve the 'illegal byte sequence' error notification.

## Package Naming Convention Test
`tester.sh` code: 
```bash
#!/usr/bin/env bash

packageRegex='^([a-z_][a-z_0-9]*\.)*([A-z_][A-z_0-9]+)$'

echo -e "-----------------------------\nRegex '$packageRegex'\n"

testName() {
  echo -e "-----------------------------\n"
  newPackageName=$1
  echo $newPackageName
  if [[ $newPackageName =~ $packageRegex ]]; then
      newApplicationName=${BASH_REMATCH[2]}
      m1=${BASH_REMATCH[1]}
      m0=${BASH_REMATCH[0]}
      newApplicationCapitalizedName="$(tr '[:lower:]' '[:upper:]' <<< ${newApplicationName:0:1})${newApplicationName:1}"
      newDirectoryName=${newPackageName//\./\/}

      echo "m0 |$m0|"
      echo "m1 |$m1|"
      echo "newApplicationName |$newApplicationName|"
      echo "newApplicationCapitalizedName |$newApplicationCapitalizedName|"
      echo "newDirectoryName |$newDirectoryName|"

      echo $2

      if [[ $2 == ERROR* ]]; then
        exit 1
      fi
  else
    echo $3
    if [[ $3 == ERROR* ]]; then
      exit 1
    fi
  fi
}

testName "io.intrepid.ThisIsMyAppName" "Matching correctly" "ERROR: match failed **************** "
testName "io.intrepid.This1IsMyAppName" "Matching correctly" "ERROR match failed **************** "
testName "1io.intrepid.This1IsMyAppName" "ERROR false match **************** " "Failed as expected"
testName "io..intrepid.This1IsMyAppName" "ERROR false match **************** " "Failed as expected"
testName "io.intrepid.This1IsMyAppName." "ERROR false match **************** " "Failed as expected"
testName "io.intrepid.This1IsMyApp-Name" "ERROR false match **************** " "Failed as expected"
testName "io.intre_pid.ThisIsMyAppName" "Matching correctly" "ERROR: match failed **************** "
testName "io.intr_epid.This1IsMyAppName" "Matching correctly" "ERROR match failed **************** "
testName "1io.int_repid.This1IsMyAppName" "ERROR false match **************** " "Failed as expected"
testName "io..int_repid.This1IsMyAppName" "ERROR false match **************** " "Failed as expected"
testName "io.intr_epid.This1IsMyAppName." "ERROR false match **************** " "Failed as expected"
testName "io.intr_epid.This1IsMyApp-Name" "ERROR false match **************** " "Failed as expected"

echo -e "-----------------------------\nThis script has completed successfully."
```

Current and Valid result:
```-----------------------------
Regex '^([a-z_][a-z_0-9]*\.)*([A-z_][A-z_0-9]+)$'

-----------------------------

io.intrepid.ThisIsMyAppName
m0 |io.intrepid.ThisIsMyAppName|
m1 |intrepid.|
newApplicationName |ThisIsMyAppName|
newApplicationCapitalizedName |ThisIsMyAppName|
newDirectoryName |io/intrepid/ThisIsMyAppName|
Matching correctly
-----------------------------

io.intrepid.This1IsMyAppName
m0 |io.intrepid.This1IsMyAppName|
m1 |intrepid.|
newApplicationName |This1IsMyAppName|
newApplicationCapitalizedName |This1IsMyAppName|
newDirectoryName |io/intrepid/This1IsMyAppName|
Matching correctly
-----------------------------

1io.intrepid.This1IsMyAppName
Failed as expected
-----------------------------

io..intrepid.This1IsMyAppName
Failed as expected
-----------------------------

io.intrepid.This1IsMyAppName.
Failed as expected
-----------------------------

io.intrepid.This1IsMyApp-Name
Failed as expected
-----------------------------

io.intre_pid.ThisIsMyAppName
m0 |io.intre_pid.ThisIsMyAppName|
m1 |intre_pid.|
newApplicationName |ThisIsMyAppName|
newApplicationCapitalizedName |ThisIsMyAppName|
newDirectoryName |io/intre_pid/ThisIsMyAppName|
Matching correctly
-----------------------------

io.intr_epid.This1IsMyAppName
m0 |io.intr_epid.This1IsMyAppName|
m1 |intr_epid.|
newApplicationName |This1IsMyAppName|
newApplicationCapitalizedName |This1IsMyAppName|
newDirectoryName |io/intr_epid/This1IsMyAppName|
Matching correctly
-----------------------------

1io.int_repid.This1IsMyAppName
Failed as expected
-----------------------------

io..int_repid.This1IsMyAppName
Failed as expected
-----------------------------

io.intr_epid.This1IsMyAppName.
Failed as expected
-----------------------------

io.intr_epid.This1IsMyApp-Name
Failed as expected
-----------------------------
This script has completed successfully.
```