### PR TITLE
Coverage Updates

### DIFF
--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -44,7 +44,7 @@ task testCoverage(type: JacocoReport, dependsOn: ["test${buildVariant}UnitTest",
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/testCoverage/coverage.xml"
+        xml.destination "${buildDir}/reports/jacoco/testCoverage/jacoco.xml"
     }
 }
 
@@ -70,7 +70,7 @@ task unitTestCoverage(type: JacocoReport, dependsOn: "test${buildVariant}UnitTes
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/unitTestCoverage/coverage.xml"
+        xml.destination "${buildDir}/reports/jacoco/unitTestCoverage/jacoco.xml"
     }
 }
 
@@ -87,7 +87,7 @@ task instrumentationTestCoverage(type: JacocoReport, dependsOn: "spoon${buildVar
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/instrumentationTestCoverage/coverage.xml"
+        xml.destination "${buildDir}/reports/jacoco/instrumentationTestCoverage/jacoco.xml"
     }
 }
 

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -23,7 +23,7 @@ def coverageClassDirs = fileTree(
 )
 
 def unitTestCoverageData = "${buildDir}/jacoco/test${buildVariant}UnitTest.exec"
-def instrumentationTestCoverageData = "${buildDir}/spoon/${buildVariantDirectory}/coverage/merged-coverage.ec"
+def instrumentationTestCoverageData = "${buildDir}/spoon-output/${buildVariantDirectory}/coverage/merged-coverage.ec"
 
 // testCoverageEnabled messes up debugging/etc, so we want it disabled most of times.
 // unit test coverage reports seems to work fine even with the flag disabled, but the

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -54,11 +54,8 @@ task unitTestCoverage(type: JacocoReport, dependsOn: "test${buildVariant}UnitTes
     sourceDirectories = coverageSourceDirs
     classDirectories = fileTree(
             dir: "${buildDir}/intermediates/classes/${buildVariantDirectory}",
-            includes: ['**/*Presenter*',
-                       '**/utils/*'
-                       // Add any additional testable classes here
-            ],
-            excludes: ['**/*Activity.class',
+            excludes: [*coverageClassDirs.excludes.asList(),
+                       '**/*Activity.class',
                        '**/*Fragment.class',
                        '**/*Service.class',
                        '**/*Application.class'

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,12 @@ buildscript {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" } // TODO remove this once spoon 2.0.0 is stable
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
+        classpath "com.jaredsburrows:gradle-spoon-plugin:1.3.0"
+        classpath "com.squareup.spoon:spoon-runner:2.0.0-SNAPSHOT" // TODO update/remove this once spoon 2.0.0 is stable
         classpath 'io.fabric.tools:gradle:1.25.1'
         classpath "gradle.plugin.io.intrepid:static-analysis:1.0.3"
     }


### PR DESCRIPTION
This does a couple testing and coverage-related things

- Switch to a new Spoon plugin since the current one is incompatible with Android Gradle Plugin 3.x. This requires using a snapshot version of Spoon but that will hopefully be temporary, and is preferable to not having this work at all.
- Adjust the unit test coverage config to exclude UI classes but otherwise include everything
- Rename `coverage.xml` to `jacoco.xml` in Jacoco coverage reports, which allows a particular Jenkins plugin to read the coverage report and post the coverage number to PRs.