### PR TITLE
Updated static analysis tool to 1.1.0 and libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,24 +91,24 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation('com.crashlytics.sdk.android:crashlytics:2.7.1@aar') {
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {
         transitive = true
     }
 
     // Support libraries
-    def supportVersion = "27.0.2"
+    def supportVersion = "27.1.0"
     implementation "com.android.support:support-v4:$supportVersion"
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:recyclerview-v7:$supportVersion"
     implementation "com.android.support:design:$supportVersion"
 
     // Google play services
-    def googlePlayVersion = "11.8.0"
+    def googlePlayVersion = "12.0.0"
     implementation "com.google.android.gms:play-services-base:$googlePlayVersion"
 
     // Rx
-    implementation "io.reactivex.rxjava2:rxjava:2.1.8"
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.1"
+    implementation "io.reactivex.rxjava2:rxjava:2.1.12"
+    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
 
     // Jake Wharton/Square
     def retrofitVersion = "2.3.0"
@@ -121,11 +121,12 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"
 
+    // https://github.com/JakeWharton/butterknife/issues/1074 for ObsoleteLintCustomCheck
     def butterKnifeVersion = "8.8.1"
     implementation "com.jakewharton:butterknife:$butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
-    implementation 'com.jakewharton.timber:timber:4.6.0'
-    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.jakewharton.timber:timber:4.7.0'
+    implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Other
     implementation "io.intrepid.commonutils:commonutils:0.2.3"

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="4" by="lint 3.0.1">
+
+    <issue
+        id="ObsoleteLintCustomCheck"
+        message="Lint found one or more custom checks using its older Java API; these checks are still run in compatibility mode, but this causes duplicated parsing, and in the next version lint will no longer include this legacy mode. Make sure the following lint detectors are upgraded to the new API: butterknife.lint.InvalidR2UsageDetector">
+        <location
+            file="app"/>
+    </issue>
+
+    <issue
+        id="AllowBackup"
+        message="On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute `android:fullBackupContent` to specify an `@xml` resource which configures which files to backup. More info: https://developer.android.com/training/backup/autosyncapi.html"
+        errorLine1="    &lt;application"
+        errorLine2="    ^">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="8"
+            column="5"/>
+    </issue>
+
+</issues>

--- a/app/src/main/res/layout/fragment_example2.xml
+++ b/app/src/main/res/layout/fragment_example2.xml
@@ -15,6 +15,7 @@
         android:id="@+id/example2_previous_ip"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textIsSelectable="true"
         android:textSize="16sp"
         />
 
@@ -23,6 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
+        android:textIsSelectable="true"
         android:textSize="16sp"
         />
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "com.jaredsburrows:gradle-spoon-plugin:1.3.0"
         classpath "com.squareup.spoon:spoon-runner:2.0.0-SNAPSHOT" // TODO update/remove this once spoon 2.0.0 is stable
-        classpath 'io.fabric.tools:gradle:1.25.1'
-        classpath "gradle.plugin.io.intrepid:static-analysis:1.0.3"
+        classpath 'io.fabric.tools:gradle:1.25.2'
+        classpath "gradle.plugin.io.intrepid:static-analysis:1.1.0"
     }
 }
 


### PR DESCRIPTION
With this update, it leaves two lint warnings in the baseline. 

One being an obsolete lint warning in Butterknife (https://github.com/JakeWharton/butterknife/issues/1074) and one being an issue with `AllowBackup` not being set in the manifest (https://stackoverflow.com/questions/12648373/what-is-androidallowbackup). 

Let me know if there's anything funky with the library upgrades that I'm just mindlessly bumping to the next version. 